### PR TITLE
[WIP] Offline site copy poc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ logs
 *.log
 npm-debug.log*
 
+.DS_Store
+
 # Runtime data
 pids
 *.pid
@@ -29,3 +31,4 @@ node_modules/
 
 # git commit_id of the app
 commit_id.txt
+tmp/*

--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ Snapshot web sites using puppeteer
 
 GET `/screenshot?url=SITE_TO_SNAPSHOT_URL`
   + Create a PNG screenshot of the site for the supplied URL param
+
+### Getting Started
+1. `docker-compose build`
+0. `docker-compose up`
+0. Access the app on http://localhost:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,12 @@ version: '3'
 services:
   snapshoteer:
     build: .
+    volumes:
+      - ./:/node_app
+      - node_modules:/node_app/node_modules
     environment:
       - PORT=8080
     ports:
       - "8080:8080"
+volumes:
+  node_modules:


### PR DESCRIPTION
create a useable offline copy of a website by downloading the required html, CSS and JS files. Possibly use case if to create static Ouroboros talk page copies

Run this app locally and then use the `/download` path for a known URL to download an offline copy, e.g. 
http://localhost:8080/download?url=https%3A%2F%2Ftalk.penguinwatch.org%2F%23%2Fsubjects%2FAPZ000fkzl